### PR TITLE
Add handover function for domainnames and bump versions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+TRANSIP API V5.14
+
+NEW
+- Added a function to handover a domain from a TransIP account to another TransIP account.
+
 TRANSIP API V5.9
 
 NEW

--- a/Transip/ColocationService.php
+++ b/Transip/ColocationService.php
@@ -16,7 +16,7 @@ class Transip_ColocationService
 	/** The SOAP service that corresponds with this class. */
 	const SERVICE = 'ColocationService';
 	/** The API version. */
-	const API_VERSION = '5.13';
+	const API_VERSION = '5.14';
 	/** @var SoapClient  The SoapClient used to perform the SOAP calls. */
 	protected static $_soapClient = null;
 

--- a/Transip/DnsService.php
+++ b/Transip/DnsService.php
@@ -17,7 +17,7 @@ class Transip_DnsService
 	/** The SOAP service that corresponds with this class. */
 	const SERVICE = 'DnsService';
 	/** The API version. */
-	const API_VERSION = '5.13';
+	const API_VERSION = '5.14';
 	/** @var SoapClient  The SoapClient used to perform the SOAP calls. */
 	protected static $_soapClient = null;
 

--- a/Transip/DomainService.php
+++ b/Transip/DomainService.php
@@ -23,7 +23,7 @@ class Transip_DomainService
 	/** The SOAP service that corresponds with this class. */
 	const SERVICE = 'DomainService';
 	/** The API version. */
-	const API_VERSION = '5.13';
+	const API_VERSION = '5.14';
 	/** @var SoapClient  The SoapClient used to perform the SOAP calls. */
 	protected static $_soapClient = null;
 
@@ -522,6 +522,19 @@ class Transip_DomainService
 	public static function requestAuthCode($domainName)
 	{
 		return self::_getSoapClient(array_merge(array($domainName), array('__method' => 'requestAuthCode')))->requestAuthCode($domainName);
+	}
+
+	/**
+	 * Handover a Domain to another TransIP User. Please be aware that this will NOT change the owner contact information
+	 * at the registry. If you want to change the domain owner at the registry, then you should execute a 'setOwner'.
+	 *
+	 * @param string $domainName The domain name you want to hand over.
+	 * @param string $targetAccountname the target account name
+	 * @throws ApiException on error
+	 */
+	public static function handover($domainName, $targetAccountname)
+	{
+		return self::_getSoapClient(array_merge(array($domainName, $targetAccountname), array('__method' => 'handover')))->handover($domainName, $targetAccountname);
 	}
 }
 

--- a/Transip/ForwardService.php
+++ b/Transip/ForwardService.php
@@ -16,7 +16,7 @@ class Transip_ForwardService
 	/** The SOAP service that corresponds with this class. */
 	const SERVICE = 'ForwardService';
 	/** The API version. */
-	const API_VERSION = '5.13';
+	const API_VERSION = '5.14';
 	/** @var SoapClient  The SoapClient used to perform the SOAP calls. */
 	protected static $_soapClient = null;
 

--- a/Transip/HaipService.php
+++ b/Transip/HaipService.php
@@ -17,7 +17,7 @@ class Transip_HaipService
 	/** The SOAP service that corresponds with this class. */
 	const SERVICE = 'HaipService';
 	/** The API version. */
-	const API_VERSION = '5.13';
+	const API_VERSION = '5.14';
 	/** @var SoapClient  The SoapClient used to perform the SOAP calls. */
 	protected static $_soapClient = null;
 

--- a/Transip/PropositionService.php
+++ b/Transip/PropositionService.php
@@ -15,7 +15,7 @@ class Transip_PropositionService
 	/** The SOAP service that corresponds with this class. */
 	const SERVICE = 'PropositionService';
 	/** The API version. */
-	const API_VERSION = '5.13';
+	const API_VERSION = '5.14';
 	/** @var SoapClient  The SoapClient used to perform the SOAP calls. */
 	protected static $_soapClient = null;
 

--- a/Transip/VpsService.php
+++ b/Transip/VpsService.php
@@ -22,7 +22,7 @@ class Transip_VpsService
 	/** The SOAP service that corresponds with this class. */
 	const SERVICE = 'VpsService';
 	/** The API version. */
-	const API_VERSION = '5.13';
+	const API_VERSION = '5.14';
 	/** @var SoapClient  The SoapClient used to perform the SOAP calls. */
 	protected static $_soapClient = null;
 

--- a/Transip/WebhostingService.php
+++ b/Transip/WebhostingService.php
@@ -22,7 +22,7 @@ class Transip_WebhostingService
 	/** The SOAP service that corresponds with this class. */
 	const SERVICE = 'WebhostingService';
 	/** The API version. */
-	const API_VERSION = '5.13';
+	const API_VERSION = '5.14';
 	/** @var SoapClient  The SoapClient used to perform the SOAP calls. */
 	protected static $_soapClient = null;
 


### PR DESCRIPTION
TRANSIP API V5.14

NEW
- Added a function to handover a domain from a TransIP account to another TransIP account.