### PR TITLE
Request a new token when revoked and perform same request

### DIFF
--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -179,7 +179,7 @@ class GuzzleClient extends HttpClient
         return HttpClientException::genericRequestException($exception);
     }
 
-    private function performRequest(string $method, $url, $options): ?ResponseInterface
+    private function performRequest(string $method, string $url, array $options): ?ResponseInterface
     {
         $method = strtolower($method);
         if (!in_array($method, ['get', 'post', 'put', 'delete', 'patch'])) {


### PR DESCRIPTION
The API's token is cached by default for one day. Once you revoke a token via de control panel you receive the "Your access token has been revoked" exception. Because the token is cached, every following request will get this same exception. The API client could easily clear the token from the cache because it is invalid and request a new token. When we've received a new token we can perform the request again and return the response.

Since the API client handles the generation and renewal of tokens automatically I believe this logic should also be implemented in the API client.

I've thought about catching this exception in my application, clearing the cache and token and perform the same request again. But that would mean I'd have to put the same try/catch logic around every API call unless I would wrap everything in a closure or something and pass it to a single method that handles the token renewal. That just didn't feel right.