### PR TITLE
Allow classes to be extended

### DIFF
--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -16,7 +16,7 @@ class ApiException extends RuntimeException
     /**
      * @var ResponseInterface $response
      */
-    private $response;
+    protected $response;
 
     /**
      * @param string $message

--- a/src/Exception/HttpBadResponseException.php
+++ b/src/Exception/HttpBadResponseException.php
@@ -24,12 +24,12 @@ class HttpBadResponseException extends RuntimeException
     /**
      * @var Exception $innerException
      */
-    private $innerException;
+    protected $innerException;
 
     /**
      * @var ResponseInterface $response
      */
-    private $response;
+    protected $response;
 
     /**
      * @param string            $message

--- a/src/Exception/HttpClientException.php
+++ b/src/Exception/HttpClientException.php
@@ -10,7 +10,7 @@ class HttpClientException extends RuntimeException
     /**
      * @var Exception $innerException
      */
-    private $innerException;
+    protected $innerException;
 
     /**
      * @param string    $message

--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -16,7 +16,7 @@ class GuzzleClient extends HttpClient
     /**
      * @var Client $client
      */
-    private $client;
+    protected $client;
 
     public function __construct(string $endpoint)
     {
@@ -179,7 +179,7 @@ class GuzzleClient extends HttpClient
         $this->parseResponseHeaders($response);
     }
 
-    private function exceptionHandler(Exception $exception): void
+    protected function exceptionHandler(Exception $exception): void
     {
         if ($exception instanceof BadResponseException) {
             if ($exception->hasResponse()) {
@@ -196,7 +196,7 @@ class GuzzleClient extends HttpClient
         throw HttpClientException::genericRequestException($exception);
     }
 
-    private function checkAndSetTestModeToOptions(array $options): array
+    protected function checkAndSetTestModeToOptions(array $options): array
     {
         if ($this->testMode == false) {
             return $options;

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -61,22 +61,22 @@ abstract class HttpClient implements HttpClientInterface
     /**
      * @var int
      */
-    private $rateLimitLimit = -1;
+    protected $rateLimitLimit = -1;
 
     /**
      * @var int
      */
-    private $rateLimitRemaining = -1;
+    protected $rateLimitRemaining = -1;
 
     /**
      * @var int
      */
-    private $rateLimitReset = -1;
+    protected $rateLimitReset = -1;
 
     /**
      * @var string
      */
-    private $chosenTokenExpiry = '1 day';
+    protected $chosenTokenExpiry = '1 day';
 
     public function __construct(string $endpoint)
     {
@@ -146,7 +146,7 @@ abstract class HttpClient implements HttpClientInterface
         $this->rateLimitReset     = $response->getHeader("X-Rate-Limit-Reset")[0] ?? -1;
     }
 
-    private function getFingerPrintFromKey(string $privateKey): string
+    protected function getFingerPrintFromKey(string $privateKey): string
     {
         return hash('SHA512', $privateKey);
     }

--- a/src/Repository/AuthRepository.php
+++ b/src/Repository/AuthRepository.php
@@ -80,7 +80,7 @@ class AuthRepository extends ApiRepository
         return intval($expirationTime);
     }
 
-    private function createSignature(string $privateKey, array $parameters): string
+    protected function createSignature(string $privateKey, array $parameters): string
     {
         // Fixup our private key, copy-pasting the key might lead to whitespace faults
         if (!preg_match(

--- a/src/TransipAPI.php
+++ b/src/TransipAPI.php
@@ -64,7 +64,7 @@ class TransipAPI
     /**
      * @var HttpClientInterface $httpClient
      */
-    private $httpClient;
+    protected $httpClient;
 
     /**
      * @param string                $customerLoginName           The loginName used to login to the TransIP Control Panel.


### PR DESCRIPTION
Please allow users to extend all classes as they see fit, by avoiding the use of private properties and using protected properties instead.