### PR TITLE
Support Symfony 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.2.0|^8.0",
         "ext-json": "*",
         "ext-openssl": "*",
-        "symfony/cache": "^3.4|^4.4|^5.0|^6.0",
+        "symfony/cache": "^3.4|^4.4|^5.0|^6.0|^7.0",
         "psr/cache": "^1.0.1|^3.0",
         "php-http/client-common": "^2.5",
         "php-http/discovery": "^1.14",


### PR DESCRIPTION
Quickfix, next should be to drop the complete requirement on `symfony/cache` and rely on interfaces.