### PR TITLE
Update GuzzleClient.php for deprecation warning php8.4

### DIFF
--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -26,7 +26,7 @@ class GuzzleClient extends HttpClient
      */
     private $client;
 
-    public function __construct(string $endpoint, Client $client = null)
+    public function __construct(string $endpoint, ?Client $client = null)
     {
         $this->client = $client ?? new Client();
         parent::__construct($endpoint);


### PR DESCRIPTION
method argument Client $client =null gives a deprecation warning.

Implicitly nullable parameter declarations deprecated

